### PR TITLE
macOS icon support

### DIFF
--- a/src/api/macos/mod.rs
+++ b/src/api/macos/mod.rs
@@ -13,14 +13,7 @@ use objc::{
 };
 use objc_id::Id;
 use objc_foundation::{INSObject, NSObject};
-use cocoa::{
-    base::{nil, YES},
-    appkit::{
-        NSApp, NSApplication, NSApplicationActivateIgnoringOtherApps, NSMenu, NSMenuItem,
-        NSRunningApplication, NSStatusBar, NSStatusItem, NSWindow
-    },
-    foundation::{NSAutoreleasePool, NSString}
-};
+use cocoa::{appkit::{NSApp, NSApplication, NSApplicationActivateIgnoringOtherApps, NSImage, NSImageView, NSMenu, NSMenuItem, NSRunningApplication, NSStatusBar, NSStatusItem, NSWindow}, base::{nil, YES}, foundation::{NSAutoreleasePool, NSString}};
 
 mod callback;
 use callback::*;
@@ -28,21 +21,30 @@ use callback::*;
 pub struct TrayItemMacOS {
     name: String,
     menu: *mut objc::runtime::Object,
-    pool: *mut objc::runtime::Object,
+    _pool: *mut objc::runtime::Object,
+    icon: Option<*mut objc::runtime::Object>,
     main_thread: Option<JoinHandle<()>>
 }
 
 impl TrayItemMacOS {
 
-    pub fn new(title: &str, icon: &str) -> Result<Self, TIError> {
+    pub fn new(title: &str, icon: &str) -> Result<Self, TIError>
+    {
 
         unsafe {
 
             let pool = NSAutoreleasePool::new(nil);
 
-            let mut t = TrayItemMacOS {
+            let icon = Some(icon).filter(|icon| !icon.is_empty());
+            let icon = icon.map(|icon_name| {
+                let icon_name = NSString::alloc(nil).init_str(icon_name);
+                NSImage::imageNamed_(NSImage::alloc(nil), icon_name)
+            });
+
+            let t = TrayItemMacOS {
                 name: title.to_string(),
-                pool: pool,
+                _pool: pool,
+                icon,
                 menu: NSMenu::new(nil).autorelease(),
                 main_thread: None
             };
@@ -55,10 +57,12 @@ impl TrayItemMacOS {
 
     }
 
-    pub fn set_icon(&self, icon: &str) -> Result<(), TIError> {
-
-        todo!()
-
+    pub fn set_icon(&mut self, icon: &str) -> Result<(), TIError> {
+        unsafe {
+            let icon_name = NSString::alloc(nil).init_str(icon);
+            self.icon = Some(NSImage::imageNamed_(NSImage::alloc(nil), icon_name));
+        }
+        Ok(())
     }
 
     pub fn add_label(&mut self, label: &str) -> Result<(), TIError> {
@@ -124,7 +128,11 @@ impl TrayItemMacOS {
 
             let item = NSStatusBar::systemStatusBar(nil).statusItemWithLength_(-1.0);
             let title = NSString::alloc(nil).init_str(&self.name);
-            item.setTitle_(title);
+            if let Some(icon) = self.icon {
+                let _: () = msg_send![item, setImage:icon];
+            } else {
+                item.setTitle_(title);
+            }
             item.setMenu_(self.menu);
 
             let current_app = NSRunningApplication::currentApplication(nil);


### PR DESCRIPTION
Adds support for icons on macOS. They need to be bundled, in the `Resources` folder of an app.