### PR TITLE
for 'set_icon_template' method implements a way to load binary image

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,3 +16,9 @@ pub type TrayItemImpl = windows::TrayItemWindows;
 
 #[cfg(target_os = "macos")]
 pub type TrayItemImpl = macos::TrayItemMacOS;
+
+#[cfg(target_os = "macos")]
+pub enum  IconType {
+    Blob(&'static [u8]),
+    Name(&'static str)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ mod api;
 mod error;
 pub use error::TIError;
 
+#[cfg(target_os = "macos")]
+pub use api::IconType;
 pub struct TrayItem(api::TrayItemImpl);
 
 impl TrayItem {


### PR DESCRIPTION
**for 'set_icon_template' method implements a way to load binary image**

+ only mac osx;
+ such as following code; default size(20.0,20.0);
```rust
let mut tray = TrayItem::new("OA3.0", "icon").unwrap();
tray.add_label("Tray Label").unwrap();
tray.add_menu_item("home page", || { println("running!"); }) .unwrap();
let inner = tray.inner_mut();
let blob = include_bytes!("path to image);
inner.set_icon_template(tray_item::IconType::Blob(blob)).unwrap();
inner.add_quit_item("Quit");
inner.display();
```