### PR TITLE
Fix copy/paste error mesage for separators, make TIError impl std::error::Error

### DIFF
--- a/src/api/windows/mod.rs
+++ b/src/api/windows/mod.rs
@@ -187,7 +187,7 @@ impl TrayItemWindows {
             if winuser::InsertMenuItemW(self.info.hmenu, item_idx, 1, &item as *const MENUITEMINFOW)
                 == 0
             {
-                return Err(get_win_os_error("Error inserting menu item"));
+                return Err(get_win_os_error("Error inserting menu separator"));
             }
         }
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::error;
+
 #[derive(Debug)]
 struct Location {
     file: &'static str,
@@ -9,6 +11,8 @@ pub struct TIError {
     cause: String,
     location: Option<Location>,
 }
+
+impl error::Error for TIError {}
 
 impl TIError {
     #[allow(dead_code)]


### PR DESCRIPTION
Adding an impl for `std::error::Error`  for `TIError` to better play nice with [anyhow](https://docs.rs/anyhow/latest/anyhow/)