### PR TITLE
Removing Sync trait requirement for generic 'F' in lib::TrayItem::add…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl TrayItem {
 
     pub fn add_menu_item<F>(&mut self, label: &str, cb: F) -> Result<(), TIError>
     where
-        F: Fn() + Send + Sync + 'static,
+        F: Fn() + Send + 'static,
     {
         self.0.add_menu_item(label, cb)
     }


### PR DESCRIPTION
…_menu_item to be able to compile for windows

Atm, compiling the windows example returns the error: 
```rust
   Compiling tray-item v0.8.0 (D:\Dev\Rust\git\tray-item-rs)
   Compiling windows v0.1.0 (D:\Dev\Rust\git\tray-item-rs\examples\windows)
error[E0277]: `Sender<Message>` cannot be shared between threads safely
  --> src\main.rs:24:32
   |
24 |       tray.add_menu_item("Quit", move || {
   |            -------------         ^------
   |            |                     |
   |  __________|_____________________within this `[closure@src\main.rs:24:32: 24:39]`
   | |          |
   | |          required by a bound introduced by this call
25 | |         quit_tx.send(Message::Quit).unwrap();
26 | |     })
   | |_____^ `Sender<Message>` cannot be shared between threads safely
   |
   = help: within `[closure@src\main.rs:24:32: 24:39]`, the trait `Sync` is not implemented for `Sender<Message>`
note: required because it's used within this closure
  --> src\main.rs:24:32
   |
24 |     tray.add_menu_item("Quit", move || {
   |                                ^^^^^^^
note: required by a bound in `TrayItem::add_menu_item`
  --> D:\Dev\Rust\git\tray-item-rs\src\lib.rs:43:26
   |
43 |         F: Fn() + Send + Sync + 'static,
   |                          ^^^^ required by this bound in `TrayItem::add_menu_item`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `windows` due to previous error
```

target = `x86_64-pc-windows-msvc`
rustc = `rustc 1.67.1 (d5a82bbd2 2023-02-07)`

DID NOT TEST ON ANY OTHER OS

(This is my first pull request if i did anything wrong tell me)