### PR TITLE
fix(ksni): add id property to tray

### DIFF
--- a/src/api/linux_ksni/mod.rs
+++ b/src/api/linux_ksni/mod.rs
@@ -18,6 +18,10 @@ pub struct TrayItemLinux {
 }
 
 impl ksni::Tray for Tray {
+    fn id(&self) -> String {
+        self.title.clone()
+    }
+
     fn title(&self) -> String {
         self.title.clone()
     }


### PR DESCRIPTION
In some environments the (e.g. Gnome with AppIndicator extension), the tray icon will not show up if the `id` is missing. To not break BC, I'm re-using the already mandatory title as ID.