### PR TITLE
use embed-resource for resource compilation

### DIFF
--- a/examples/windows/Cargo.toml
+++ b/examples/windows/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 tray-item = { path = "../../" }
 
 [build-dependencies]
-windres = "*"
+embed-resource = "2.3"

--- a/examples/windows/build.rs
+++ b/examples/windows/build.rs
@@ -1,5 +1,5 @@
-use windres::Build;
+extern crate embed_resource;
 
 fn main() {
-    Build::new().compile("tray-example.rc").unwrap();
+    embed_resource::compile("tray-example.rc", embed_resource::NONE);
 }


### PR DESCRIPTION
Use `embed-resource` instead of `windreg` for resource embedding on Windows example. Both `windreg` and `winapi` seem to be stale or abandoned now.

Tested with `cargo run` to verify that demo icon is included correctly:

![tray-item-fix](https://github.com/olback/tray-item-rs/assets/1000663/970018a3-bda2-4059-b859-1c73e5da714b)
