### PR TITLE
Set icon image with PNG file on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gtk = { version = "0.18", optional = true }
 padlock = "0.2"
 
 [target.'cfg(target_os="windows")'.dependencies.windows-sys]
-version = "0.48.0"
+version = "0.52.0"
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub struct TrayItem(api::TrayItemImpl);
 #[derive(Clone)]
 pub enum IconSource {
     Resource(&'static str),
-    #[cfg(all(target_os = "linux", feature = "ksni"))]
+    #[cfg(any(target_os = "macos", all(target_os = "linux", feature = "ksni")))]
     Data {
         height: i32,
         width: i32,


### PR DESCRIPTION
Currently we can only set icon image via resource name, which needs a whole app bundle to work.
This PR enables setting icon image from PNG file directly.