### PR TITLE
Fix windows api issue on x86 architecture

### DIFF
--- a/src/api/windows/mod.rs
+++ b/src/api/windows/mod.rs
@@ -254,6 +254,15 @@ impl TrayItemWindows {
         nid.hWnd = self.info.hwnd;
         nid.uID = 1;
         nid.uFlags = NIF_TIP;
+
+        #[cfg(target_arch = "x86")]
+        {
+            let mut tip_data = [0u16; 128];
+            tip_data[..wide_tooltip.len()].copy_from_slice(&wide_tooltip);
+            nid.szTip = tip_data;
+        }
+
+        #[cfg(not(target_arch = "x86"))]
         nid.szTip[..wide_tooltip.len()].copy_from_slice(&wide_tooltip);
 
         unsafe {


### PR DESCRIPTION
When compiling to x86 target (`i686-pc-windows-msvc`), an error occurs because the struct `NOTIFYICONDATAW` in `windows-sys` has different define between `x86` and others.

```rust
#[repr(C)]
#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`*"]
#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
pub struct NOTIFYICONDATAW {
    pub cbSize: u32,
    pub hWnd: super::super::Foundation::HWND,
    pub uID: u32,
    pub uFlags: NOTIFY_ICON_DATA_FLAGS,
    pub uCallbackMessage: u32,
    pub hIcon: super::WindowsAndMessaging::HICON,
    pub szTip: [u16; 128],
    pub dwState: NOTIFY_ICON_STATE,
    pub dwStateMask: u32,
    pub szInfo: [u16; 256],
    pub Anonymous: NOTIFYICONDATAW_0,
    pub szInfoTitle: [u16; 64],
    pub dwInfoFlags: NOTIFY_ICON_INFOTIP_FLAGS,
    pub guidItem: ::windows_sys::core::GUID,
    pub hBalloonIcon: super::WindowsAndMessaging::HICON,
}


#[repr(C, packed(1))]
#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`*"]
#[cfg(target_arch = "x86")]
#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
pub struct NOTIFYICONDATAW {
    pub cbSize: u32,
    pub hWnd: super::super::Foundation::HWND,
    pub uID: u32,
    pub uFlags: NOTIFY_ICON_DATA_FLAGS,
    pub uCallbackMessage: u32,
    pub hIcon: super::WindowsAndMessaging::HICON,
    pub szTip: [u16; 128],
    pub dwState: NOTIFY_ICON_STATE,
    pub dwStateMask: u32,
    pub szInfo: [u16; 256],
    pub Anonymous: NOTIFYICONDATAW_0,
    pub szInfoTitle: [u16; 64],
    pub dwInfoFlags: NOTIFY_ICON_INFOTIP_FLAGS,
    pub guidItem: ::windows_sys::core::GUID,
    pub hBalloonIcon: super::WindowsAndMessaging::HICON,
}
```

Compiling will be failed due to `#[repr(C, packed(1))]`.

```shell
error[E0793]: reference to packed field is unaligned
   --> src\api\windows\mod.rs:257:9
    |
257 |         nid.szTip[..wide_tooltip.len()].copy_from_slice(&wide_tooltip);
    |         ^^^^^^^^^
    |
    = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)

For more information about this error, try `rustc --explain E0793`.
```