### PR TITLE
Fix crash on windows (error code: 1410) when tray icon created again

### DIFF
--- a/src/api/windows/funcs.rs
+++ b/src/api/windows/funcs.rs
@@ -130,9 +130,8 @@ pub(crate) unsafe fn init_window() -> Result<WindowInfo, TIError> {
     let mut wnd = unsafe { mem::zeroed::<WNDCLASSW>() };
     wnd.lpfnWndProc = Some(window_proc);
     wnd.lpszClassName = class_name.as_ptr();
-    if RegisterClassW(&wnd) == 0 {
-        return Err(get_win_os_error("Error creating window class"));
-    }
+    
+    RegisterClassW(&wnd);
 
     let hwnd = CreateWindowExW(
         0,


### PR DESCRIPTION
It's common to create tray icon again in a GUI application. However, the process crashes when tray icon created at the **second** time.

Because, 

> All window classes that an application registers are unregistered when it terminates.

See https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerclassw#remarks

When the application creates tray icon again, calling to `RegisterClassW` will return error.

Maybe, we can ignore errors from calling `RegisterClassW` just like tauri-apps/tray-icon does.

See https://github.com/tauri-apps/tray-icon/blob/302f29e48c2dc4cec1adc9ef67a80d93c0c90b16/src/platform_impl/windows/mod.rs#L89
