### PR TITLE
Update to ksni0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ ksni = ["dep:ksni"]
 libappindicator = ["dep:libappindicator", "dep:gtk"]
 
 [dependencies]
-ksni = { version = "0.2.0", optional = true }
 libappindicator = { version = "0.9", optional = true } # Tray icon
+ksni = { version = "0.3.1", features = ["blocking"], optional = true }
 gtk = { version = "0.18", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]

--- a/src/api/linux_ksni/mod.rs
+++ b/src/api/linux_ksni/mod.rs
@@ -1,5 +1,6 @@
 use crate::{IconSource, TIError};
-use ksni::{menu::StandardItem, Handle, Icon};
+use ksni::blocking::TrayMethods;
+use ksni::{blocking::Handle, menu::StandardItem, Icon};
 use std::sync::{Arc, Mutex};
 
 enum TrayItem {
@@ -85,15 +86,14 @@ impl ksni::Tray for Tray {
 
 impl TrayItemLinux {
     pub fn new(title: &str, icon: IconSource) -> Result<Self, TIError> {
-        let svc = ksni::TrayService::new(Tray {
+        let tray_handle = Tray {
             title: title.to_string(),
             icon,
             actions: vec![],
             next_id: 0,
-        });
+        };
 
-        let handle = svc.handle();
-        svc.spawn();
+        let handle = tray_handle.spawn().unwrap();
 
         Ok(Self { tray: handle })
     }


### PR DESCRIPTION
According to ksni 0.3.0 changelog: All methods of `TrayService` have been moved into `TrayMethods`. `TrayMethods` is a trait that is implemented by default for all `T where T: Tray` ([RFC #445]), so you no longer need to wrap a `Tray` with `TrayService` to call the spawn method.
@olback  please review and lets trigger a new crate release please :D